### PR TITLE
fixed jellyfin api endpoint for media server add

### DIFF
--- a/main.py
+++ b/main.py
@@ -701,10 +701,13 @@ async def test_connection(
             if type.lower() == "plex":
                 test_url = f"{url}/library/sections"
                 headers = {"X-Plex-Token": token}
-            else:  # Jellyfin or Emby
+            elif type.lower() == "jellyfin":
+                test_url = f"{url}/System/Info/Public"
+                headers = {"X-MediaBrowser-Token": api_key}
+            elif type.lower() == "emby":
                 test_url = f"{url}/Library/SelectableMediaFolders"
                 headers = {"X-MediaBrowser-Token": api_key}
-            
+
             logger.debug(f"Attempting to connect to {test_url}")
             async with aiohttp.ClientSession() as session:
                 try:


### PR DESCRIPTION
I changed the test_url for jellyfin, looks like it is not the same as emby. I have tested and it now works.