### PR TITLE
Fix Jellyfin authentication for modern installations

### DIFF
--- a/main.py
+++ b/main.py
@@ -708,7 +708,7 @@ async def test_connection(
                 headers = {"X-Plex-Token": token}
             elif type.lower() == "jellyfin":
                 test_url = f"{url}/System/Info/Public"
-                headers = {"X-MediaBrowser-Token": api_key}
+                headers = {"Authorization": f'MediaBrowser Token="{api_key}"'}
             elif type.lower() == "emby":
                 test_url = f"{url}/Library/SelectableMediaFolders"
                 headers = {"X-MediaBrowser-Token": api_key}

--- a/media_server_service.py
+++ b/media_server_service.py
@@ -117,9 +117,9 @@ class JellyfinServer(MediaServerBase):
     async def scan_path(self, path: str) -> Dict[str, Any]:
         """Scan a path in Jellyfin"""
         headers = {
-            "X-MediaBrowser-Token": self.api_key
+            "Authorization": f'MediaBrowser Token="{self.api_key}"'
         }
-        
+
         # Trigger library scan
         scan_url = urljoin(self.url, "/Library/Refresh")
         async with aiohttp.ClientSession() as session:
@@ -305,9 +305,9 @@ class MediaServerScanner:
 
     async def _scan_jellyfin(self, server: JellyfinServer, path: str) -> Dict[str, Any]:
         headers = {
-            "X-MediaBrowser-Token": server.api_key
+            "Authorization": f'MediaBrowser Token="{server.api_key}"'
         }
-        
+
         # Trigger library scan
         scan_url = urljoin(server.url, "/Library/Refresh")
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
## Problem
Autosync fails to refresh Jellyfin libraries when `EnableLegacyAuthorization` is disabled, which is the default setting in modern Jellyfin installations.

## Root Cause
Autosync uses the legacy `X-MediaBrowser-Token` header inherited from Emby. Modern Jellyfin requires the `Authorization: MediaBrowser Token="<key>"` header format when legacy auth is disabled.

## Solution
Updated `JellyfinServer.scan_path()`, `MediaServerScanner._scan_jellyfin()`, and the test connection endpoint to use the modern authentication header format per the official Jellyfin API documentation.

## Testing
- ✅ Tested with Jellyfin 10.11.5 with `EnableLegacyAuthorization=false` (default)
- ✅ Tested with Jellyfin 10.11.5 with `EnableLegacyAuthorization=true` (backward compatible)
- ✅ Library refresh operations succeed with both configurations
- ✅ Connection test endpoint continues to work

## Backward Compatibility
The modern header format is accepted by Jellyfin regardless of the legacy auth setting, ensuring backward compatibility.

## Reference
Official Jellyfin API Authentication documentation: https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f