### PR TITLE
Add per-instance quality profile sync exclusions

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -61,6 +61,7 @@ instances:
     search_on_sync: false
     enabled_events:
       - "Import"
+    excluded_quality_profile_ids: []  # e.g. [7] to skip profile ID 7 from syncing to this instance
 
   - name: "sonarrmux"
     type: "sonarr"
@@ -73,6 +74,7 @@ instances:
     search_on_sync: false
     enabled_events:
       - "Import"
+    excluded_quality_profile_ids: []
 
   - name: "radarr4k"
     type: "radarr"
@@ -83,6 +85,7 @@ instances:
     search_on_sync: false
     enabled_events:
       - "Import"
+    excluded_quality_profile_ids: []  # e.g. [7] to skip profile ID 7 from syncing to this instance
 
   - name: "radarrmux"
     type: "radarr"
@@ -93,6 +96,7 @@ instances:
     search_on_sync: false
     enabled_events:
       - "Import"
+    excluded_quality_profile_ids: []
     # Optional: Rewrite rules for instance
     #rewrite:
     #  - from_path: "/mnt/plex/Movies - Remux"

--- a/main.py
+++ b/main.py
@@ -236,7 +236,8 @@ async def add_instance(
     language_profile_id: Optional[int] = Form(None),
     season_folder: Optional[bool] = Form(False),
     search_on_sync: Optional[bool] = Form(False),
-    enabled_events: List[str] = Form([])
+    enabled_events: List[str] = Form([]),
+    excluded_quality_profile_ids: List[int] = Form([])
 ):
     """Add a new instance to the configuration."""
     global sonarr_instances, radarr_instances
@@ -251,14 +252,15 @@ async def add_instance(
         "root_folder_path": root_folder_path,
         "quality_profile_id": quality_profile_id,
         "search_on_sync": search_on_sync,
-        "enabled_events": enabled_events
+        "enabled_events": enabled_events,
+        "excluded_quality_profile_ids": excluded_quality_profile_ids
     }
-    
+
     # Add Sonarr-specific fields
     if type.lower() == "sonarr":
         instance_data["language_profile_id"] = language_profile_id or 1
         instance_data["season_folder"] = season_folder
-    
+
     # Check if instance with same name and type already exists
     for idx, inst in enumerate(config.get("instances", [])):
         if inst.get("name") == name and inst.get("type") == type:
@@ -451,6 +453,7 @@ async def edit_instance(
     season_folder: Optional[bool] = Form(False),
     search_on_sync: Optional[bool] = Form(False),
     enabled_events: List[str] = Form([]),
+    excluded_quality_profile_ids: List[int] = Form([]),
     rewrite_from: Optional[List[str]] = Form([]),
     rewrite_to: Optional[List[str]] = Form([])
 ):
@@ -467,14 +470,15 @@ async def edit_instance(
         "root_folder_path": root_folder_path,
         "quality_profile_id": quality_profile_id,
         "search_on_sync": search_on_sync,
-        "enabled_events": enabled_events
+        "enabled_events": enabled_events,
+        "excluded_quality_profile_ids": excluded_quality_profile_ids
     }
-    
+
     # Add Sonarr-specific fields
     if type.lower() == "sonarr":
         instance_data["language_profile_id"] = language_profile_id or 1
         instance_data["season_folder"] = season_folder
-    
+
     # Add rewrite rules if any
     if rewrite_from and rewrite_to:
         instance_data["rewrite"] = [
@@ -771,6 +775,20 @@ async def debug_webhook(payload: Dict[str, Any], request: Request) -> Dict[str, 
         "eventType": payload.get("eventType", "unknown"),
         "payload": payload,
     }
+
+async def get_source_quality_profile_id(instance, media_id: int, media_type: str) -> Optional[int]:
+    """Look up the quality profile ID for a series or movie in its source instance."""
+    endpoint = "series" if media_type == "sonarr" else "movie"
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{instance.base_url}/api/v3/{endpoint}/{media_id}"
+            async with session.get(url, headers=instance.headers, timeout=aiohttp.ClientTimeout(total=10), ssl=False) as resp:
+                if resp.status == 200:
+                    return (await resp.json()).get("qualityProfileId")
+    except Exception as e:
+        logger.debug(f"  ├─ Could not fetch quality profile for {media_type} id={media_id}: {e}")
+    return None
+
 
 async def handle_sonarr_delete(payload: Dict[str, Any], instances: List[SonarrInstance], sync_interval: float, config: Dict[str, Any]):
     """Handle series or episode deletion by syncing across instances and scanning media servers"""
@@ -1141,10 +1159,22 @@ async def process_webhook(payload: Dict[str, Any], event_type: str, webhook_id: 
             
             # Filter instances that have this event type enabled
             valid_instances = [
-                inst for inst in sonarr_instances 
+                inst for inst in sonarr_instances
                 if event_type.lower() in [e.lower() for e in inst.enabled_events]
             ]
-            
+
+            # Filter by source quality profile exclusions
+            source = next((i for i in sonarr_instances if i.name.lower() == (payload.get("instanceName") or "").lower()), None)
+            if valid_instances and source and source.excluded_quality_profile_ids:
+                series_id = payload.get("series", {}).get("id")
+                series_title = payload.get("series", {}).get("title", "Unknown")
+                if series_id:
+                    source_profile_id = await get_source_quality_profile_id(source, series_id, "sonarr")
+                    if source_profile_id and source_profile_id in source.excluded_quality_profile_ids:
+                        target_names = ", ".join(i.name for i in valid_instances)
+                        logger.info(f"  ├─ Sync excluded: \033[1m{series_title}\033[0m (profile {source_profile_id}) — would have synced to: \033[1m{target_names}\033[0m")
+                        valid_instances = []
+
             logger.debug(f"  ├─ Found {len(valid_instances)} Sonarr instances for event {event_type}")
             
             if not valid_instances:
@@ -1232,10 +1262,22 @@ async def process_webhook(payload: Dict[str, Any], event_type: str, webhook_id: 
             
             # Filter instances that have this event type enabled
             valid_instances = [
-                inst for inst in radarr_instances 
+                inst for inst in radarr_instances
                 if event_type.lower() in [e.lower() for e in inst.enabled_events]
             ]
-            
+
+            # Filter by source quality profile exclusions
+            source = next((i for i in radarr_instances if i.name.lower() == (payload.get("instanceName") or "").lower()), None)
+            if valid_instances and source and source.excluded_quality_profile_ids:
+                movie_id = payload.get("movie", {}).get("id")
+                movie_title = payload.get("movie", {}).get("title", "Unknown")
+                if movie_id:
+                    source_profile_id = await get_source_quality_profile_id(source, movie_id, "radarr")
+                    if source_profile_id and source_profile_id in source.excluded_quality_profile_ids:
+                        target_names = ", ".join(i.name for i in valid_instances)
+                        logger.info(f"  ├─ Sync excluded: \033[1m{movie_title}\033[0m (profile {source_profile_id}) — would have synced to: \033[1m{target_names}\033[0m")
+                        valid_instances = []
+
             logger.debug(f"  ├─ Found {len(valid_instances)} Radarr instances for event {event_type}")
             
             if not valid_instances:

--- a/models.py
+++ b/models.py
@@ -330,6 +330,7 @@ class SonarrInstance(BaseModel):
     season_folder: bool = True
     search_on_sync: bool = False
     enabled_events: List[str] = []
+    excluded_quality_profile_ids: List[int] = []
     rewrite: Optional[List[Dict[str, str]]] = None
 
     @property
@@ -432,6 +433,7 @@ class RadarrInstance(BaseModel):
     quality_profile_id: int
     search_on_sync: bool = False
     enabled_events: List[str] = []
+    excluded_quality_profile_ids: List[int] = []
     rewrite: Optional[List[Dict[str, str]]] = None
 
     @property

--- a/templates/add_instance.html
+++ b/templates/add_instance.html
@@ -56,6 +56,12 @@
                     <div class="form-text">The quality profile to use for new content</div>
                 </div>
 
+                <div class="mb-3" id="excludedProfilesContainer" style="display:none;">
+                    <label class="form-label">Don't Sync These Profiles</label>
+                    <div id="excludedProfilesList" class="form-control p-2" style="max-height:160px;overflow-y:auto;"></div>
+                    <div class="form-text">Series imported with these quality profiles will stay on this instance only</div>
+                </div>
+
                 <div class="mb-3" id="seasonFolderSection">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="season_folder" name="season_folder">
@@ -235,6 +241,20 @@ async function loadInstanceData() {
                 qualityProfileSelect.innerHTML += `<option value="${profile.id}">${profile.name}</option>`;
             });
             qualityProfileSelect.disabled = false;
+
+            const excludedContainer = document.getElementById('excludedProfilesContainer');
+            const excludedList = document.getElementById('excludedProfilesList');
+            excludedList.innerHTML = '';
+            profilesData.profiles.forEach(profile => {
+                excludedList.innerHTML += `
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox"
+                            name="excluded_quality_profile_ids" value="${profile.id}"
+                            id="excl_${profile.id}">
+                        <label class="form-check-label" for="excl_${profile.id}">${profile.name}</label>
+                    </div>`;
+            });
+            excludedContainer.style.display = '';
         }
     } catch (error) {
         connectionStatus.innerHTML = `<span class="text-danger">Failed to load instance data: ${error.message}</span>`;
@@ -374,6 +394,8 @@ document.addEventListener('DOMContentLoaded', function() {
         qualityProfileSelect.disabled = true;
         rootFolderSelect.innerHTML = '<option value="">Select a root folder...</option>';
         qualityProfileSelect.innerHTML = '<option value="">Select a quality profile...</option>';
+        document.getElementById('excludedProfilesList').innerHTML = '';
+        document.getElementById('excludedProfilesContainer').style.display = 'none';
         connectionStatus.innerHTML = '';
         apiKeyStatus.innerHTML = '';
         apiKeyInput.type = 'text';
@@ -452,6 +474,11 @@ document.addEventListener('DOMContentLoaded', function() {
             formData.append('enabled_events', event);
         });
         
+        // Add excluded quality profile IDs
+        document.querySelectorAll('input[name="excluded_quality_profile_ids"]:checked').forEach(input => {
+            formData.append('excluded_quality_profile_ids', input.value);
+        });
+
         // Add rewrite rules
         const rewriteRules = document.querySelectorAll('.rewrite-rule');
         rewriteRules.forEach((rule, index) => {
@@ -462,7 +489,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 formData.append(`rewrite_to`, toPath);
             }
         });
-        
+
         try {
             const response = await fetch('/test-connection', {
                 method: 'POST',

--- a/templates/edit_instance.html
+++ b/templates/edit_instance.html
@@ -53,6 +53,12 @@
                     <div class="form-text">The quality profile to use for new content</div>
                 </div>
 
+                <div class="mb-3" id="excludedProfilesContainer">
+                    <label class="form-label">Don't Sync These Profiles</label>
+                    <div id="excludedProfilesList" class="form-control p-2" style="max-height:160px;overflow-y:auto;"></div>
+                    <div class="form-text">Series imported with these quality profiles will stay on this instance only</div>
+                </div>
+
                 {% if instance.type == "sonarr" %}
                 <div class="mb-3">
                     <div class="form-check">
@@ -245,6 +251,20 @@ async function loadInstanceData() {
                 qualityProfileSelect.innerHTML += `<option value="${profile.id}" ${selected}>${profile.name}</option>`;
             });
             qualityProfileSelect.disabled = false;
+
+            const currentExcluded = {{ instance.excluded_quality_profile_ids | default([]) | tojson }};
+            const excludedList = document.getElementById('excludedProfilesList');
+            excludedList.innerHTML = '';
+            profilesData.profiles.forEach(profile => {
+                const checked = currentExcluded.includes(profile.id) ? 'checked' : '';
+                excludedList.innerHTML += `
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox"
+                            name="excluded_quality_profile_ids" value="${profile.id}"
+                            id="excl_${profile.id}" ${checked}>
+                        <label class="form-check-label" for="excl_${profile.id}">${profile.name}</label>
+                    </div>`;
+            });
         }
     } catch (error) {
         connectionStatus.innerHTML = `<span class="text-danger">Failed to load instance data: ${error.message}</span>`;
@@ -425,6 +445,11 @@ document.addEventListener('DOMContentLoaded', function() {
             formData.append('enabled_events', event);
         });
         
+        // Add excluded quality profile IDs
+        document.querySelectorAll('input[name="excluded_quality_profile_ids"]:checked').forEach(input => {
+            formData.append('excluded_quality_profile_ids', input.value);
+        });
+
         // Add rewrite rules
         const rewriteRules = document.querySelectorAll('.rewrite-rule');
         rewriteRules.forEach((rule, index) => {
@@ -435,7 +460,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 formData.append(`rewrite_to`, toPath);
             }
         });
-        
+
         try {
             // First test the connection
             const testResponse = await fetch('/test-connection', {


### PR DESCRIPTION
## Summary

- Adds the ability to mark specific quality profiles on a source instance as excluded from outgoing sync. When a webhook fires, autosync looks up the series/movie's quality profile from the source instance and skips all syncing if that profile is in the exclusion list.
- Fixes a silent bug where `instanceName` case mismatch (e.g. Sonarr sending `"Sonarr"` vs a lowercase config name) caused the source instance to never be found.
- Adds a "Don't Sync These Profiles" checklist to the add/edit instance UI, populated from the instance's own quality profiles after a successful test connection.

## Use case

Users with a standard Sonarr instance (e.g. anime + 1080p profiles) and a 4K-only Sonarr instance no longer have anime synced across. The exclusion is configured on the source instance — any series imported using an excluded profile stays on that instance only.

## Changes

- `models.py` — `excluded_quality_profile_ids: List[int] = []` on `SonarrInstance` and `RadarrInstance`
- `main.py` — `get_source_quality_profile_id()` helper; source-side exclusion filter for Sonarr and Radarr; case-insensitive `instanceName` matching; exclusion log line showing title, profile ID, and skipped instances; updated POST handlers
- `templates/add_instance.html` + `edit_instance.html` — checklist UI with dark mode support, pre-checked on edit
- `config-example.yaml` — documented new field

## Test plan

- [ ] Configure `excluded_quality_profile_ids` on a source Sonarr/Radarr instance via the UI
- [ ] Trigger an import for a series/movie using that quality profile
- [ ] Confirm log line: `Sync excluded: <title> (profile X) — would have synced to: <instances>`
- [ ] Confirm nothing was synced to target instances
- [ ] Confirm a series using a non-excluded profile still syncs normally
- [ ] Verify edit form pre-checks saved exclusions on reload